### PR TITLE
Simplify JAEGER_URL by not requiring a Route to be present

### DIFF
--- a/openshift/cloud-native-demo_backend_template.yml
+++ b/openshift/cloud-native-demo_backend_template.yml
@@ -14,7 +14,7 @@ parameters:
 - name: JAEGER_URL
   description: URL address of the Jaeger Collector
   displayName: Jaeger URL
-  value: 'http://jaeger-collector-tracing.192.168.64.80.nip.io/api/traces'
+  value: 'http://jaeger-collector.tracing:14268/api/traces'
   required: true
 # Objects defined for the template
 objects:


### PR DESCRIPTION
Since Jaeger is meant to be deployed in the tracing namespace, we can
take advantage of that fact, by using the URL of the service.
With this change no Route needs to be present and also it doesn't need
to be changed between environments