### PR TITLE
Add support for deploying the application into an arbitrary namespace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,11 @@ podTemplate(name: 'maven33', label: 'maven33', cloud: 'openshift', serviceAccoun
     stage("Test") {
       sh "mvn test"
     }
+
+    stage("Use appropriate namespace") {
+        sh "oc project ${OPENSHIFT_NAMESPACE}"
+    }
+
     stage("Deploy") {
       sh "mvn  -Popenshift -DskipTests clean fabric8:deploy"
     }

--- a/README-Jenkins-Pipeline.md
+++ b/README-Jenkins-Pipeline.md
@@ -1,0 +1,34 @@
+# Utilize Jenkins pipeline build
+
+## Prerequisites
+
+- The Openshift Sync Jenkins plugin needs to be configured to watch the namespace where the application will be deployed to
+
+- The Jenkins SA needs to able to watch various resources in the namespace where the application will be deployed to
+
+The easiest way to give Jenkins SA such permissions is to execute
+
+```bash
+    $ oc adm policy add-cluster-role-to-user edit system:serviceaccount:infra:jenkins -n $(oc project -q)
+```
+
+- The user has logged in to Openshift and is using the namespace where the application is going to be deployed 
+
+## Create pipeline
+
+```bash
+    $ ./create-pipeline.sh
+```
+
+The script works by utilizing the `openshift/jenkins-bc` "template" and substituting the namespace in the provided placeholder
+The BuildConfig that is created contains an environment variable whose value is the namespace where the application will be deployed.
+Finally the `podTemplate` of the pipeline utilizes the aforementioned environment variable to switch namespaces using `oc project`.
+
+## Start pipeline
+
+```bash
+    $ ./start-pipeline.sh
+```
+
+  
+ 

--- a/create-pipeline.sh
+++ b/create-pipeline.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Creates jenkins pipeline for a namespace
+# The only argument passed to the script is the namespace / project into which the pipeline BC will be created
+# If no argument is passed, it's assumed that the namespace to be used is the current namespace
+
+# The script assumes that oc login has been performed
+
+namespace=${1:-$(oc project -q)}
+
+substituted_var_filename=jenkins-bc-temp.yml
+
+# change the namespace placeholder
+sed -e "s/changeme/${namespace}/g" openshift/jenkins-bc.yaml > ${substituted_var_filename}
+
+# actually create the JenkinsPipeline BuildConfig
+oc apply -f ${substituted_var_filename}
+
+# remove temporary file
+rm ${substituted_var_filename}
+

--- a/openshift/jenkins-bc.yaml
+++ b/openshift/jenkins-bc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  name: cloud-native-backend-changeme
+  namespace: changeme
+spec:
+  source:
+    git:
+      ref: master
+      uri: https://github.com/snowdrop/cloud-native-backend.git
+    type: Git
+  strategy:
+    jenkinsPipelineStrategy:
+      jenkinsfilePath: Jenkinsfile
+      env:
+          - name: "OPENSHIFT_NAMESPACE"
+            value: "changeme"
+    type: JenkinsPipeline
+  triggers:
+  - github:
+      secret: secret101
+    type: GitHub
+  - generic:
+      secret: secret101
+    type: Generic

--- a/start-pipeline.sh
+++ b/start-pipeline.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Start jenkins pipeline for a namespace
+# The only argument passed to the script is the namespace / project into which the pipeline BC will be created
+# If no argument is passed, it's assumed that the namespace to be used is the current namespace
+
+# The script assumes that oc login has been performed
+
+namespace=${1:-$(oc project -q)}
+
+oc start-build cloud-native-backend-${namespace}


### PR DESCRIPTION
Be default when using Openshift - Jenkins integration, the application
gets deployed into the namespace where Jenkins is run.
By passing the namespace as an argument to the BuildConfig and then
using that namespace in the podTemplate we have the ability to run the
application into whichever namespace we like